### PR TITLE
Change default

### DIFF
--- a/adafruit_is31fl3741/__init__.py
+++ b/adafruit_is31fl3741/__init__.py
@@ -308,7 +308,7 @@ class IS31FL3741_colorXY(IS31FL3741):
                 self[addrs[self.g_offset]] = green
                 self[addrs[self.b_offset]] = blue
 
-    def pixel(self, x: int, y: int, color: int = 0) -> Union[int, None]:
+    def pixel(self, x: int, y: int, color: Optional[int] = None) -> Union[int, None]:
         """
         Set or retrieve RGB color of pixel at position (X,Y).
 


### PR DESCRIPTION
The default value of `None` for the `color` parameter in `IS31FL3741_colorXY.fill` would cause errors if they were actually used as per discussion in https://github.com/adafruit/Adafruit_CircuitPython_IS31FL3741/pull/8

This PR changes that default the value to 0 instead, which should accomplish what I'm assuming the original intent of the `None` default was: turning off the pixels.