### PR TITLE
Require busdevice

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@
 Adafruit-Blinka
 adafruit-circuitpython-framebuf
 adafruit-circuitpython-register
+adafruit-circuitpython-busdevice
 Pillow


### PR DESCRIPTION
.. it's used by this library. Without it, the package fails to import in a fresh venve:
```
jepler@bert:~/src/bundle/libraries/drivers/is31fl3741$ python3 -mvenv _env
jepler@bert:~/src/bundle/libraries/drivers/is31fl3741$ _env/bin/pip install -r requirements.txt 
...Successfully installed Adafruit-Blinka-7.0.2 Adafruit-PlatformDetect-3.20.1 Adafruit-PureIO-1.1.9 Pillow-9.0.1 adafruit-circuitpython-framebuf-1.4.9 adafruit-circuitpython-register-1.9.8 pyftdi-0.53.3 pyserial-3.5 pyusb-1.2.1
jepler@bert:~/src/bundle/libraries/drivers/is31fl3741$ ./_env/bin/python3 -c 'import adafruit_is31fl3741'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/jepler/src/bundle/libraries/drivers/is31fl3741/adafruit_is31fl3741/__init__.py", line 28, in <module>
    from adafruit_bus_device import i2c_device
ModuleNotFoundError: No module named 'adafruit_bus_device'
```