### PR TITLE
remove support for pypixelbuf and _pixelbuf

### DIFF
--- a/adafruit_is31fl3741/is31fl3741_pixelbuf.py
+++ b/adafruit_is31fl3741/is31fl3741_pixelbuf.py
@@ -15,15 +15,7 @@
 * Author(s): Mark Komus, Damien P. George, Scott Shawcroft, Carter Nelson, Rose Hooper
 """
 
-# pylint: disable=ungrouped-imports
-try:
-    import adafruit_pixelbuf
-except ImportError:
-    try:
-        import _pixelbuf as adafruit_pixelbuf
-    except ImportError:
-        import adafruit_pypixelbuf as adafruit_pixelbuf
-
+import adafruit_pixelbuf
 
 try:
     # Used only for typing


### PR DESCRIPTION
Not used for CircuitPython 7 or later.