### PR TITLE
Convert annotation from pillow to circuitpython_typing

### DIFF
--- a/adafruit_is31fl3741/__init__.py
+++ b/adafruit_is31fl3741/__init__.py
@@ -32,7 +32,7 @@ from adafruit_register.i2c_bit import RWBit
 try:
     # Used only for typing
     from typing import Optional, Tuple, Union  # pylint: disable=unused-import
-    from PIL.ImageFile import ImageFile
+    from circuitpython_typing.pil import Image
     from adafruit_framebuf import FrameBuffer
     import busio
 except ImportError:
@@ -335,7 +335,7 @@ class IS31FL3741_colorXY(IS31FL3741):
                 )
         return None
 
-    def image(self, img: Union[FrameBuffer, ImageFile]) -> None:
+    def image(self, img: Union[FrameBuffer, Image]) -> None:
         """Copy an in-memory image to the LED matrix. Image should be in
         24-bit format (e.g. "RGB888") and dimensions should match matrix,
         this isn't super robust yet or anything.

--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -1,3 +1,5 @@
 # SPDX-FileCopyrightText: 2022 Alec Delaney, for Adafruit Industries
 #
 # SPDX-License-Identifier: Unlicense
+
+pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@
 Adafruit-Blinka
 adafruit-circuitpython-framebuf
 adafruit-circuitpython-busdevice
-pillow
+adafruit-circuitpython-typing~=1.6
 adafruit-circuitpython-register


### PR DESCRIPTION
Since the library is designed not to require downloading `pillow`, the use of `circuitpython_typing.pil.Image` is used for the type annotation instead.