### PR TITLE
add write() to python driver so it can be used with pixelbuf.

### DIFF
--- a/adafruit_is31fl3741/__init__.py
+++ b/adafruit_is31fl3741/__init__.py
@@ -33,6 +33,7 @@ try:
     # Used only for typing
     from typing import Optional, Tuple, Union  # pylint: disable=unused-import
     from circuitpython_typing.pil import Image
+    from circuitpython_typing import ReadableBuffer
     from adafruit_framebuf import FrameBuffer
     import busio
 except ImportError:
@@ -232,6 +233,18 @@ class IS31FL3741:
                 self._pixel_buffer[180] = 0
                 i2c.write(self._pixel_buffer, start=180, end=352)
                 self._pixel_buffer[180] = save
+
+    def write(self, mapping: Tuple, buffer: ReadableBuffer) -> None:
+        """
+        Write buf out on the I2C bus to the IS31FL3741.
+
+        :param mapping: map the pixels in the buffer to the order addressed by the driver chip
+        :param buffer: The bytes to clock out. No assumption is made about color order
+        :return: None
+        """
+        for pos, data in enumerate(buffer):
+            self[mapping[pos]] = data
+        self.show()
 
 
 IS3741_RGB = (0 << 4) | (1 << 2) | (2)  # Encode as R,G,B

--- a/adafruit_is31fl3741/__init__.py
+++ b/adafruit_is31fl3741/__init__.py
@@ -243,7 +243,8 @@ class IS31FL3741:
         :return: None
         """
         for pos, data in enumerate(buffer):
-            self[mapping[pos]] = data
+            if mapping[pos] != 65535:
+                self[mapping[pos]] = data
         self.show()
 
 

--- a/adafruit_is31fl3741/is31fl3741_pixelbuf.py
+++ b/adafruit_is31fl3741/is31fl3741_pixelbuf.py
@@ -19,9 +19,10 @@ import adafruit_pixelbuf
 
 try:
     # Used only for typing
-    from typing import Optional, Type
+    from typing import Optional, Type, Union
     from types import TracebackType
     import is31fl3741
+    from . import IS31FL3741
 except ImportError:
     pass
 
@@ -78,7 +79,7 @@ class IS31FL3741_PixelBuf(adafruit_pixelbuf.PixelBuf):
 
     def __init__(
         self,
-        is31: is31fl3741.IS31FL3741,
+        is31: Union[is31fl3741.IS31FL3741, IS31FL3741],
         mapping: tuple,
         *,
         addr: int = 0x30,

--- a/examples/is31fl3741_rgbmatrix_all_animations.py
+++ b/examples/is31fl3741_rgbmatrix_all_animations.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-FileCopyrightText: 2023 Neradoc https://neradoc.me
+# SPDX-License-Identifier: MIT
+"""
+This example repeatedly displays all available animations
+on the IS31FL3741 13x9 RGB Matrix, at a five second interval.
+"""
+import board
+from adafruit_led_animation.animation.blink import Blink
+from adafruit_led_animation.animation.sparklepulse import SparklePulse
+from adafruit_led_animation.animation.comet import Comet
+from adafruit_led_animation.animation.chase import Chase
+from adafruit_led_animation.animation.pulse import Pulse
+from adafruit_led_animation.animation.sparkle import Sparkle
+from adafruit_led_animation.animation.rainbowchase import RainbowChase
+from adafruit_led_animation.animation.rainbowsparkle import RainbowSparkle
+from adafruit_led_animation.animation.rainbowcomet import RainbowComet
+from adafruit_led_animation.animation.solid import Solid
+from adafruit_led_animation.animation.colorcycle import ColorCycle
+from adafruit_led_animation.animation.rainbow import Rainbow
+from adafruit_led_animation.animation.customcolorchase import CustomColorChase
+from adafruit_led_animation.sequence import AnimationSequence
+from adafruit_led_animation.color import PURPLE, WHITE, AMBER, JADE, MAGENTA, ORANGE
+from adafruit_is31fl3741 import PREFER_BUFFER
+from adafruit_is31fl3741.adafruit_rgbmatrixqt import Adafruit_RGBMatrixQT
+from adafruit_is31fl3741.is31fl3741_pixelbuf import IS31FL3741_PixelBuf
+
+# i2c = board.I2C()
+i2c = board.STEMMA_I2C()
+
+########################################################################
+# Instantiate the nice IS31FL3741
+########################################################################
+
+is31 = Adafruit_RGBMatrixQT(i2c, allocate=PREFER_BUFFER)
+is31.set_led_scaling(0xFF)
+is31.global_current = 0xFF
+is31.enable = True
+
+########################################################################
+# Setup the mapping and PixelBuf instance
+########################################################################
+
+WIDTH = 13
+HEIGHT = 9
+LEDS_MAP = tuple(
+    (
+        address
+        for y in range(HEIGHT)
+        for x in range(WIDTH)
+        for address in Adafruit_RGBMatrixQT.pixel_addrs(x, y)
+    )
+)
+pixels = IS31FL3741_PixelBuf(is31, LEDS_MAP, init=False, auto_write=False)
+
+########################################################################
+# Run animations
+########################################################################
+
+blink = Blink(pixels, speed=0.5, color=JADE)
+colorcycle = ColorCycle(pixels, speed=0.4, colors=[MAGENTA, ORANGE])
+comet = Comet(pixels, speed=0.01, color=PURPLE, tail_length=10, bounce=True)
+chase = Chase(pixels, speed=0.1, size=3, spacing=6, color=WHITE)
+pulse = Pulse(pixels, speed=0.1, period=3, color=AMBER)
+sparkle = Sparkle(pixels, speed=0.1, color=PURPLE, num_sparkles=10)
+solid = Solid(pixels, color=JADE)
+rainbow = Rainbow(pixels, speed=0.1, period=2)
+sparkle_pulse = SparklePulse(pixels, speed=0.1, period=3, color=JADE)
+rainbow_comet = RainbowComet(pixels, speed=0.1, tail_length=7, bounce=True)
+rainbow_chase = RainbowChase(pixels, speed=0.1, size=3, spacing=2, step=8)
+rainbow_sparkle = RainbowSparkle(pixels, speed=0.1, num_sparkles=15)
+custom_color_chase = CustomColorChase(
+    pixels, speed=0.1, size=2, spacing=3, colors=[ORANGE, WHITE, JADE]
+)
+
+animations = AnimationSequence(
+    comet,
+    blink,
+    rainbow_sparkle,
+    chase,
+    pulse,
+    sparkle,
+    rainbow,
+    solid,
+    rainbow_comet,
+    sparkle_pulse,
+    rainbow_chase,
+    custom_color_chase,
+    advance_interval=5,
+    auto_clear=True,
+)
+while True:
+    animations.animate()

--- a/examples/is31fl3741_rgbmatrix_animation_sequence.py
+++ b/examples/is31fl3741_rgbmatrix_animation_sequence.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-FileCopyrightText: 2023 Neradoc https://neradoc.me
+# SPDX-License-Identifier: MIT
+"""
+This example repeatedly displays all available animations
+on the IS31FL3741 13x9 RGB Matrix, at a five second interval.
+"""
+import board
+from adafruit_led_animation.animation.blink import Blink
+from adafruit_led_animation.animation.comet import Comet
+from adafruit_led_animation.animation.colorcycle import ColorCycle
+from adafruit_led_animation.sequence import AnimationSequence
+from adafruit_led_animation.color import PURPLE, JADE
+from adafruit_is31fl3741 import PREFER_BUFFER
+from adafruit_is31fl3741.adafruit_rgbmatrixqt import Adafruit_RGBMatrixQT
+from adafruit_is31fl3741.is31fl3741_pixelbuf import IS31FL3741_PixelBuf
+
+# i2c = board.I2C()
+i2c = board.STEMMA_I2C()
+
+########################################################################
+# Instantiate the nice IS31FL3741
+########################################################################
+
+is31 = Adafruit_RGBMatrixQT(i2c, allocate=PREFER_BUFFER)
+is31.set_led_scaling(0xFF)
+is31.global_current = 0xFF
+is31.enable = True
+
+########################################################################
+# Setup the mapping and PixelBuf instance
+########################################################################
+
+WIDTH = 13
+HEIGHT = 9
+LEDS_MAP = tuple(
+    (
+        address
+        for y in range(HEIGHT)
+        for x in range(WIDTH)
+        for address in Adafruit_RGBMatrixQT.pixel_addrs(x, y)
+    )
+)
+pixels = IS31FL3741_PixelBuf(is31, LEDS_MAP, init=False, auto_write=False)
+
+########################################################################
+# Run animations
+########################################################################
+
+blink = Blink(pixels, speed=0.5, color=JADE)
+colorcycle = ColorCycle(pixels, speed=0.4)
+comet = Comet(pixels, speed=0.01, color=PURPLE, tail_length=10, bounce=True)
+
+
+animations = AnimationSequence(
+    blink,
+    comet,
+    colorcycle,
+    advance_interval=5,
+    auto_clear=True,
+)
+while True:
+    animations.animate()

--- a/examples/is31fl3741_rgbmatrix_led_animation.py
+++ b/examples/is31fl3741_rgbmatrix_led_animation.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-FileCopyrightText: 2023 Neradoc https://neradoc.me
+# SPDX-License-Identifier: MIT
+"""
+This example repeatedly displays all available animations
+on the IS31FL3741 13x9 RGB Matrix, at a five second interval.
+"""
+import board
+from adafruit_led_animation.animation.blink import Blink
+from adafruit_led_animation.color import PINK
+from adafruit_is31fl3741 import PREFER_BUFFER
+from adafruit_is31fl3741.adafruit_rgbmatrixqt import Adafruit_RGBMatrixQT
+from adafruit_is31fl3741.is31fl3741_pixelbuf import IS31FL3741_PixelBuf
+
+
+# i2c = board.I2C()
+i2c = board.STEMMA_I2C()
+
+########################################################################
+# Instantiate the nice IS31FL3741
+########################################################################
+
+is31 = Adafruit_RGBMatrixQT(i2c, allocate=PREFER_BUFFER)
+is31.set_led_scaling(0xFF)
+is31.global_current = 0xFF
+is31.enable = True
+
+########################################################################
+# Setup the mapping and PixelBuf instance
+########################################################################
+
+WIDTH = 13
+HEIGHT = 9
+LEDS_MAP = tuple(
+    (
+        address
+        for y in range(HEIGHT)
+        for x in range(WIDTH)
+        for address in Adafruit_RGBMatrixQT.pixel_addrs(x, y)
+    )
+)
+pixels = IS31FL3741_PixelBuf(is31, LEDS_MAP, init=False, auto_write=False)
+
+########################################################################
+# Run animations
+########################################################################
+
+blink = Blink(pixels, speed=0.5, color=PINK)
+
+while True:
+    blink.animate()


### PR DESCRIPTION
This adds a `write()` function to the python implementation of `IS31FL3741` driver class that matches the function available on the [core implementation](https://docs.circuitpython.org/en/latest/shared-bindings/is31fl3741/index.html#is31fl3741.write).

This allows the python implementation of `IS31FL3741` to be used with the `is31fl3741_pixelbuf.py` wrapper class in this library. Which in turn can then be used with the led_animation library.

There are 3 new examples illustrating:
- single animation, essentially the "simpletest" of this functionality
- short sequence of animations
- all existing animations in a sequence, the most advanced version that displays every currently existing animation.


All of my testing was carried out with the [13x9 RGB Matrix device](https://www.adafruit.com/product/5201).

I think this could theoretically be used with the LED Glasses as well and may negate the need for the animation helper class in the library, but I have not tried this yet.
